### PR TITLE
Upgrade quarto-webr version from 0.0.1 to 0.3.6

### DIFF
--- a/book/_extensions/coatless/webr/_extension.yml
+++ b/book/_extensions/coatless/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.0.1
+version: 0.3.6
 quarto-required: ">=1.2.198"
 contributes:
   filters:

--- a/book/_extensions/coatless/webr/monaco-editor-init.html
+++ b/book/_extensions/coatless/webr/monaco-editor-init.html
@@ -1,0 +1,10 @@
+<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/loader.js"></script>
+<script type="module" id="webr-monaco-editor-init">
+
+  // Configure the Monaco Editor's loader
+  require.config({
+    paths: {
+      'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs'
+    }
+  });
+</script>

--- a/book/_extensions/coatless/webr/template.qmd
+++ b/book/_extensions/coatless/webr/template.qmd
@@ -1,0 +1,31 @@
+---
+title: "WebR-enabled code cell"
+format: html
+engine: knitr
+#webr:
+#  show-startup-message: false      # Display status of webR initialization
+#  show-header-message: false      # Check to see if COOP&COEP headers are set for speed.
+#  packages: ['ggplot2', 'dplyr'] # Pre-install dependencies
+#  home-dir: "/home/rstudio"      # Customize where the working directory is
+#  base-url: ''                   # Base URL used for downloading R WebAssembly binaries
+#  service-worker-url: ''         # URL from where to load JavaScript worker scripts when loading webR with the ServiceWorker communication channel.
+filters:
+- webr
+---
+
+## Demo
+
+This is a webr-enabled code cell in a Quarto HTML document.
+
+```{webr-r}
+1 + 1 
+```
+
+```{webr-r}
+fit = lm(mpg ~ am, data = mtcars)
+summary(fit)
+```
+
+```{webr-r}
+plot(pressure)
+```

--- a/book/_extensions/coatless/webr/webr-context-interactive.html
+++ b/book/_extensions/coatless/webr/webr-context-interactive.html
@@ -1,0 +1,204 @@
+<button class="btn btn-default btn-webr" disabled type="button" id="webr-run-button-{{WEBRCOUNTER}}">Loading
+  webR...</button>
+<div id="webr-editor-{{WEBRCOUNTER}}"></div>
+<div id="webr-code-output-{{WEBRCOUNTER}}" aria-live="assertive">
+  <pre style="visibility: hidden"></pre>
+</div>
+<script type="module">
+  // Retrieve webR code cell information
+  const runButton = document.getElementById("webr-run-button-{{WEBRCOUNTER}}");
+  const outputDiv = document.getElementById("webr-code-output-{{WEBRCOUNTER}}");
+  const editorDiv = document.getElementById("webr-editor-{{WEBRCOUNTER}}");
+
+  // Add a light grey outline around the code editor
+  editorDiv.style.border = "1px solid #eee";
+
+  // Load the Monaco Editor and create an instance
+  let editor;
+  require(['vs/editor/editor.main'], function () {
+    editor = monaco.editor.create(editorDiv, {
+      value: `{{WEBRCODE}}`,
+      language: 'r',
+      theme: 'vs-light',
+      automaticLayout: true,           // TODO: Could be problematic for slide decks
+      scrollBeyondLastLine: false,
+      minimap: {
+        enabled: false
+      },
+      fontSize: '17.5rem',               // Bootstrap is 1 rem
+      renderLineHighlight: "none",     // Disable current line highlighting
+      hideCursorInOverviewRuler: true  // Remove cursor indictor in right hand side scroll bar
+    });
+
+    // Dynamically modify the height of the editor window if new lines are added.
+    let ignoreEvent = false;
+    const updateHeight = () => {
+      const contentHeight = editor.getContentHeight();
+      // We're avoiding a width change
+      //editorDiv.style.width = `${width}px`;
+      editorDiv.style.height = `${contentHeight}px`;
+      try {
+        ignoreEvent = true;
+
+        // The key to resizing is this call
+        editor.layout();
+      } finally {
+        ignoreEvent = false;
+      }
+    };
+
+    // Helper function to check if selected text is empty
+    function isEmptyCodeText(selectedCodeText) {
+      return (selectedCodeText === null || selectedCodeText === undefined || selectedCodeText === "");
+    }
+
+    // Registry of keyboard shortcuts that should be re-added to each editor window
+    // when focus changes.
+    const addWebRKeyboardShortCutCommands = () => {
+      // Add a keydown event listener for Shift+Enter to run all code in cell
+      editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, () => {
+
+        // Retrieve all text inside the editor
+        executeCode(editor.getValue());
+      });
+
+      // Add a keydown event listener for CMD/Ctrl+Enter to run selected code
+      editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+
+        // Get the selected text from the editor
+        const selectedText = editor.getModel().getValueInRange(editor.getSelection());
+        // Check if no code is selected
+        if (isEmptyCodeText(selectedText)) {
+          // Obtain the current cursor position
+          let currentPosition = editor.getPosition();
+          // Retrieve the current line content
+          let currentLine = editor.getModel().getLineContent(currentPosition.lineNumber);
+
+          // Propose a new position to move the cursor to
+          let newPosition = new monaco.Position(currentPosition.lineNumber + 1, 1);
+
+          // Check if the new position is beyond the last line of the editor
+          if (newPosition.lineNumber > editor.getModel().getLineCount()) {
+            // Add a new line at the end of the editor
+            editor.executeEdits("addNewLine", [{
+            range: new monaco.Range(newPosition.lineNumber, 1, newPosition.lineNumber, 1),
+            text: "\n", 
+            forceMoveMarkers: true,
+            }]);
+          }
+          
+          // Run the entire line of code.
+          executeCode(currentLine);
+
+          // Move cursor to new position
+          editor.setPosition(newPosition);
+        } else {
+          // Code to run when Ctrl+Enter is pressed with selected code
+          executeCode(selectedText);
+        }
+      });
+    }
+
+    // Register an on focus event handler for when a code cell is selected to update
+    // what keyboard shortcut commands should work.
+    // This is a workaround to fix a regression that happened with multiple
+    // editor windows since Monaco 0.32.0 
+    // https://github.com/microsoft/monaco-editor/issues/2947
+    editor.onDidFocusEditorText(addWebRKeyboardShortCutCommands);
+
+    // Register an on change event for when new code is added to the editor window
+    editor.onDidContentSizeChange(updateHeight);
+
+    // Manually re-update height to account for the content we inserted into the call
+    updateHeight();
+  });
+
+  // Function to execute the code (accepts code as an argument)
+  async function executeCode(codeToRun) {
+    // Disable run button for code cell active
+    runButton.disabled = true;
+
+    // Create a canvas variable for graphics
+    let canvas = undefined;
+
+    // Initialize webR
+    await globalThis.webR.init();
+
+    // Setup a webR canvas by making a namespace call into the {webr} package
+    await webR.evalRVoid("webr::canvas(width={{WIDTH}}, height={{HEIGHT}})");
+
+    // Capture output data from evaluating the code
+    const result = await webRCodeShelter.captureR(codeToRun, {
+      withAutoprint: true,
+      captureStreams: true,
+      captureConditions: false//,
+      // env: webR.objs.emptyEnv, // maintain a global environment for webR v0.2.0
+    });
+
+    // Start attempting to parse the result data
+    try {
+
+      // Stop creating images
+      await webR.evalRVoid("dev.off()");
+
+      // Merge output streams of STDOUT and STDErr (messages and errors are combined.)
+      const out = result.output.filter(
+        evt => evt.type == "stdout" || evt.type == "stderr"
+      ).map((evt) => evt.data).join("\n");
+
+      // Clean the state
+      const msgs = await webR.flush();
+
+      // Output each image stored
+      msgs.forEach(msg => {
+        // Determine if old canvas can be used or a new canvas is required.
+        if (msg.type === 'canvas'){
+          // Add image to the current canvas
+          if (msg.data.event === 'canvasImage') {
+            canvas.getContext('2d').drawImage(msg.data.image, 0, 0);
+          } else if (msg.data.event === 'canvasNewPage') {
+            // Generate a new canvas element
+            canvas = document.createElement("canvas");
+            canvas.setAttribute("width", 2 * {{WIDTH}});
+            canvas.setAttribute("height", 2 * {{HEIGHT}});
+            canvas.style.width = "700px";
+            canvas.style.display = "block";
+            canvas.style.margin = "auto";
+          }
+        }
+      });
+
+      // Nullify the outputDiv of content
+      outputDiv.innerHTML = "";
+
+      // Design an output object for messages
+      const pre = document.createElement("pre");
+      if (/\S/.test(out)) {
+        // Display results as text
+        const code = document.createElement("code");
+        code.innerText = out;
+        pre.appendChild(code);
+      } else {
+        // If nothing is present, hide the element.
+        pre.style.visibility = "hidden";
+      }
+      outputDiv.appendChild(pre);
+
+      // Place the graphics on the canvas
+      if (canvas) {
+        const p = document.createElement("p");
+        p.appendChild(canvas);
+        outputDiv.appendChild(p);
+      }
+    } finally {
+      // Clean up the remaining code
+      webRCodeShelter.purge();
+      runButton.disabled = false;
+    }
+  }
+
+  // Add a click event listener to the run button
+  runButton.onclick = function () {
+    executeCode(editor.getValue());
+  };
+</script>

--- a/book/_extensions/coatless/webr/webr-context-output.html
+++ b/book/_extensions/coatless/webr/webr-context-output.html
@@ -1,0 +1,90 @@
+<div id="webr-code-output-{{WEBRCOUNTER}}" aria-live="assertive">
+  <pre style="visibility: hidden"></pre>
+</div>
+<script type="module">
+  // Retrieve webR code cell information
+  const outputDiv = document.getElementById("webr-code-output-{{WEBRCOUNTER}}");
+  
+  // Function to execute the code (accepts code as an argument)
+  async function executeOutputOnlyCode(codeToRun) {  
+    // Create a canvas variable for graphics
+    let canvas = undefined;
+
+    // Initialize webR
+    await globalThis.webR.init();
+
+    // Setup a webR canvas by making a namespace call into the {webr} package
+    await webR.evalRVoid("webr::canvas(width={{WIDTH}}, height={{HEIGHT}})");
+
+    // Capture output data from evaluating the code
+    const result = await webRCodeShelter.captureR(codeToRun, {
+      withAutoprint: true,
+      captureStreams: true,
+      captureConditions: false//,
+      // env: webR.objs.emptyEnv, // maintain a global environment for webR v0.2.0
+    });
+
+    // Start attempting to parse the result data
+    try {
+
+      // Stop creating images
+      await webR.evalRVoid("dev.off()");
+
+      // Merge output streams of STDOUT and STDErr (messages and errors are combined.)
+      const out = result.output.filter(
+        evt => evt.type == "stdout" || evt.type == "stderr"
+      ).map((evt) => evt.data).join("\n");
+
+      // Clean the state
+      const msgs = await webR.flush();
+
+      // Output each image stored
+      msgs.forEach(msg => {
+        // Determine if old canvas can be used or a new canvas is required.
+        if (msg.type === 'canvas'){
+          // Add image to the current canvas
+          if (msg.data.event === 'canvasImage') {
+            canvas.getContext('2d').drawImage(msg.data.image, 0, 0);
+          } else if (msg.data.event === 'canvasNewPage') {
+            // Generate a new canvas element
+            canvas = document.createElement("canvas");
+            canvas.setAttribute("width", 2 * {{WIDTH}});
+            canvas.setAttribute("height", 2 * {{HEIGHT}});
+            canvas.style.width = "700px";
+            canvas.style.display = "block";
+            canvas.style.margin = "auto";
+          }
+        }
+      });
+
+      // Nullify the outputDiv of content
+      outputDiv.innerHTML = "";
+
+      // Design an output object for messages
+      const pre = document.createElement("pre");
+      if (/\S/.test(out)) {
+        // Display results as text
+        const code = document.createElement("code");
+        code.innerText = out;
+        pre.appendChild(code);
+      } else {
+        // If nothing is present, hide the element.
+        pre.style.visibility = "hidden";
+      }
+      outputDiv.appendChild(pre);
+
+      // Place the graphics on the canvas
+      if (canvas) {
+        const p = document.createElement("p");
+        p.appendChild(canvas);
+        outputDiv.appendChild(p);
+      }
+    } finally {
+      // Clean up the remaining code
+      webRCodeShelter.purge();
+    }
+  }
+
+  // Run the code
+  executeOutputOnlyCode(`{{WEBRCODE}}`)
+</script>

--- a/book/_extensions/coatless/webr/webr-context-setup.html
+++ b/book/_extensions/coatless/webr/webr-context-setup.html
@@ -1,0 +1,9 @@
+<script type="module">
+// Initialization WebR
+await globalThis.webR.init();
+
+// Run R code without focusing on storing data.
+await globalThis.webR.evalRVoid(`
+{{WEBRCODE}}
+`)
+</script>	

--- a/book/_extensions/coatless/webr/webr-init.html
+++ b/book/_extensions/coatless/webr/webr-init.html
@@ -1,24 +1,156 @@
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/editor/editor.main.css" />
+
 <style>
-  .CodeMirror pre {
+  .monaco-editor pre {
     background-color: unset !important;
   }
+
   .btn-webr {
     background-color: #EEEEEE;
     border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-bottom-right-radius: 0; /* Extra styling for consistency */
+    display: inline-block;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #000;
+    text-align: center;
+    text-decoration: none;
+    -webkit-text-decoration: none;
+    -moz-text-decoration: none;
+    -ms-text-decoration: none;
+    -o-text-decoration: none;
+    vertical-align: middle;
+    -webkit-user-select: none;
+    border-color: #dee2e6;
+    border: 1px solid rgba(0,0,0,0);
+    padding: 0.375rem 0.75rem;
+    font-size: 1rem;
+    border-radius: 0.25rem;
+    transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+  }
+
+  .btn-webr:hover {
+    color: #000;
+    background-color: #e3e6ea;
+    border-color: #e1e5e9;
+  }
+
+  .btn-webr:disabled,.btn-webr.disabled,fieldset:disabled .btn-webr {
+    pointer-events: none;
+    opacity: .65
   }
 </style>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/mode/r/r.js"></script>
+
 <script type="module">
-  import { WebR } from "https://webr.r-wasm.org/v0.1.0/webr.mjs";
-  // Removed {SW_URL: '/'} for the moment
-  globalThis.webR = new WebR();
+
+  // Start a timer
+  const initializeWebRTimerStart = performance.now();
+
+  // Determine if we need to install R packages
+  var installRPackagesList = [{{INSTALLRPACKAGESLIST}}];
+  // Check to see if we have an empty array, if we do set to skip the installation.
+  var setupRPackages = !(installRPackagesList.indexOf("") !== -1);
+
+  // Display a startup message?
+  var showStartupMessage = {{SHOWSTARTUPMESSAGE}};
+  var showHeaderMessage = {{SHOWHEADERMESSAGE}};
+  if (showStartupMessage) {
+
+    // Create the outermost div element
+    var quartoTitleMeta = document.createElement("div");
+    quartoTitleMeta.classList.add("quarto-title-meta");
+
+    // Create the first inner div element
+    var firstInnerDiv = document.createElement("div");
+
+    // Create the second inner div element with "WebR Status" heading 
+    // and contents
+    var secondInnerDiv = document.createElement("div");
+    secondInnerDiv.classList.add("quarto-title-meta-heading");
+    secondInnerDiv.innerText = "WebR Status";
+
+    // Add another inner div
+    var secondInnerDivContents = document.createElement("div");
+    secondInnerDivContents.classList.add("quarto-title-meta-contents");
+
+    // Describe the WebR state
+    var startupMessageWebR = document.createElement("p");
+    startupMessageWebR.innerText = "🟡 Loading...";
+    startupMessageWebR.setAttribute("id", "startup");
+    // Add `aria-live` to auto-announce the startup status to screen readers
+    startupMessageWebR.setAttribute("aria-live", "assertive");
+
+    // Put everything together
+    secondInnerDivContents.appendChild(startupMessageWebR);
+
+    // Add a status indicator for COOP and COEP Headers
+    if (showHeaderMessage) {
+      var crossOriginMessage = document.createElement("p");
+      crossOriginMessage.innerText = `${crossOriginIsolated ? '🟢' : '🟡'} COOP & COEP Headers`;
+      crossOriginMessage.setAttribute("id", "coop-coep-header");
+      secondInnerDivContents.appendChild(crossOriginMessage);
+    }
+
+    firstInnerDiv.appendChild(secondInnerDiv);
+    firstInnerDiv.appendChild(secondInnerDivContents);
+    quartoTitleMeta.appendChild(firstInnerDiv);
+
+    // Add new element as last child in header element
+    var header = document.getElementById("title-block-header");
+
+    // Check if the header option is present or missing
+    if(header) {
+      // If present, directly append the child element.
+      header.appendChild(quartoTitleMeta);
+    } else {
+      // Attempt to place the new element inside a header _after_ the Monaco initialization
+      var monacoScript = document.getElementById("webr-monaco-editor-init");
+      var header = document.createElement("header");
+      header.setAttribute("id", "title-block-header");
+      // Now attempt to add the webR area to the title
+      header.appendChild(quartoTitleMeta);
+      // Include the header after the script tag
+      monacoScript.after(header);
+    }
+  }
+
+  // Retrieve the webr.mjs
+  import { WebR, ChannelType } from "https://webr.r-wasm.org/v0.2.1/webr.mjs";
+
+  // Populate WebR options with defaults or new values based on 
+  // webr meta
+  globalThis.webR = new WebR({
+    "baseURL": "{{BASEURL}}",
+    "serviceWorkerUrl": "{{SERVICEWORKERURL}}",
+    "homedir": "{{HOMEDIR}}", 
+    "channelType": {{CHANNELTYPE}}
+  });
+
+  // Initialization WebR
   await globalThis.webR.init();
+
+  // Setup a shelter
   globalThis.webRCodeShelter = await new globalThis.webR.Shelter();
+
+  // Installing Packages
+  if (showStartupMessage && setupRPackages) {
+    // If initialized, but we have packages to install switch status
+    startupMessageWebR.innerText = "🟡 Installing package dependencies..."
+    // Install packages
+    await globalThis.webR.installPackages(installRPackagesList)
+  }
+
+  // Switch to allowing code to be executed
   document.querySelectorAll(".btn-webr").forEach((btn) => {
     btn.innerText = "Run code";
     btn.disabled = false;
   });
-</script>  
+
+  // Stop timer
+  const initializeWebRTimerEnd = performance.now();
+
+  if (showStartupMessage) {
+    // If initialized, switch to a green light
+    startupMessageWebR.innerText = "🟢 Ready!"
+  }
+</script>

--- a/book/_extensions/coatless/webr/webr-serviceworker.js
+++ b/book/_extensions/coatless/webr/webr-serviceworker.js
@@ -1,1 +1,1 @@
-importScripts('https://webr.r-wasm.org/v0.1.0/webr-serviceworker.js');
+importScripts('https://webr.r-wasm.org/v0.2.1/webr-serviceworker.js');

--- a/book/_extensions/coatless/webr/webr-worker.js
+++ b/book/_extensions/coatless/webr/webr-worker.js
@@ -1,1 +1,1 @@
-importScripts('https://webr.r-wasm.org/v0.1.0/webr-worker.js');
+importScripts('https://webr.r-wasm.org/v0.2.1/webr-worker.js');

--- a/book/_extensions/coatless/webr/webr.lua
+++ b/book/_extensions/coatless/webr/webr.lua
@@ -1,16 +1,169 @@
+----
+--- Setup variables for default initialization
+
 -- Define a variable to only include the initialization once
 local hasDoneWebRSetup = false
--- Define a counter variable
-local counter = 0
+
+--- Setup default initialization values
+-- Default values taken from:
+-- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html
+
+-- Define a base compatibile version
+local baseVersionWebR = "0.2.1"
+
+-- Define where WebR can be found
+local baseUrl = ""
+local serviceWorkerUrl = ""
+
+-- Define the webR communication protocol
+local channelType = "ChannelType.Automatic"
+
+-- Define a variable to suppress exporting service workers if not required.
+-- (e.g. skipped for PostMessage or SharedArrayBuffer)
+local hasServiceWorkerFiles = true
+
+-- Define user directory
+local homeDir = "/home/web_user"
+
+-- Define whether a startup message should be displayed
+local showStartUpMessage = "true"
+
+-- Define whether header type messages should be displayed
+local showHeaderMessage = "false"
+
+-- Define an empty string if no packages need to be installed.
+local installRPackagesList = "''"
 ----
 
--- Read in the editor template
-function editorTemplateFile()
-  -- Establish a hardcoded path to where the webr-editor.html partial resides
+--- Setup variables for tracking number of code cells
+
+-- Define a counter variable
+local counter = 0
+
+----
+--- Process initialization
+
+-- Check if variable is present and not just the empty string
+function is_variable_empty(s)
+  return s == nil or s == ''
+end
+
+-- Convert the communication channel meta option into a WebROptions.channelType option
+function convertMetaChannelTypeToWebROption(input)
+  -- Create a table of conditions
+  local conditions = {
+    ["automatic"] = "ChannelType.Automatic",
+    [0] = "ChannelType.Automatic",
+    ["shared-array-buffer"] = "ChannelType.SharedArrayBuffer",
+    [1] = "ChannelType.SharedArrayBuffer",
+    ["service-worker"] = "ChannelType.ServiceWorker",
+    [2] = "ChannelType.ServiceWorker",
+    ["post-message"] = "ChannelType.PostMessage",
+    [3] = "ChannelType.PostMessage",
+  }
+  -- Subset the table to obtain the communication channel.
+  -- If the option isn't found, return automatic.
+  return conditions[input] or "ChannelType.Automatic"
+end
+
+
+-- Parse the different webr options set in the YAML frontmatter, e.g.
+--
+-- ```yaml
+-- ----
+-- webr:
+--   base-url: https://webr.r-wasm.org/[version]
+--   service-worker-url: path/to/workers/{webr-serviceworker.js, webr-worker.js}
+-- ----
+-- ```
+--
+-- 
+function setWebRInitializationOptions(meta)
+
+  -- Let's explore the meta variable data! 
+  -- quarto.log.output(meta)
+  
+  -- Retrieve the webr options from meta
+  local webr = meta.webr
+
+  -- Does this exist? If not, just return meta as we'll just use the defaults.
+  if is_variable_empty(webr) then
+    return meta
+  end
+
+  -- The base URL used for downloading R WebAssembly binaries 
+  -- https://webr.r-wasm.org/[version]/webr.mjs
+  -- Documentation:
+  -- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#baseurl
+  if not is_variable_empty(webr["base-url"]) then
+    baseUrl = pandoc.utils.stringify(webr["base-url"])
+  end
+
+  -- The communication channel mode webR uses to connect R with the web browser 
+  -- Default: "ChannelType.Automatic"
+  -- Documentation:
+  -- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#channeltype
+  if not is_variable_empty(webr["channel-type"]) then
+    channelType = convertMetaChannelTypeToWebROption(pandoc.utils.stringify(webr["channel-type"]))
+    if not (channelType == "ChannelType.Automatic" and channelType == "ChannelType.ServiceWorker") then
+      hasServiceWorkerFiles = false
+    end
+  end
+
+  -- The base URL from where to load JavaScript worker scripts when loading webR
+  -- with the ServiceWorker communication channel mode.
+  -- Documentation:
+  -- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#serviceworkerurl
+  if not is_variable_empty(webr["service-worker-url"]) then
+    serviceWorkerUrl = pandoc.utils.stringify(webr["service-worker-url"])
+  end
+
+  -- The WebAssembly user's home directory and initial working directory. Default: '/home/web_user'
+  -- Documentation:
+  -- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#homedir
+  if not is_variable_empty(webr['home-dir']) then
+    homeDir = pandoc.utils.stringify(webr["home-dir"])
+  end
+
+  -- Display a startup message indicating the WebR state at the top of the document.
+  if not is_variable_empty(webr['show-startup-message']) then
+    showStartUpMessage = pandoc.utils.stringify(webr["show-startup-message"])
+  end
+
+  -- Display a startup message indicating the WebR state at the top of the document.
+  if not is_variable_empty(webr['show-header-message']) then
+    showHeaderMessage = pandoc.utils.stringify(webr["show-header-message"])
+    if showHeaderMessage == "true" then
+      showStartUpMessage = "true"
+    end
+  end
+
+
+  -- Attempt to install different packages.
+  if not is_variable_empty(webr["packages"]) then
+    -- Create a custom list
+    local package_list = {}
+
+    -- Iterate through each list item and enclose it in quotes
+    for _, package_name in pairs(webr["packages"]) do
+      table.insert(package_list, "'" .. pandoc.utils.stringify(package_name) .. "'")
+    end
+
+    installRPackagesList = table.concat(package_list, ", ")
+  end
+
+  
+  return meta
+end
+
+
+-- Obtain a template file
+function readTemplateFile(template)
+  -- Establish a hardcoded path to where the .html partial resides
   -- Note, this should be at the same level as the lua filter.
-  -- This is crazy fragile since lua lacks a directory representation (!?!?)
+  -- This is crazy fragile since Lua lacks a directory representation (!?!?)
   -- https://quarto.org/docs/extensions/lua-api.html#includes
-  local path = quarto.utils.resolve_path("webr-editor.html") 
+  local path = quarto.utils.resolve_path(template) 
 
   -- Let's hopefully read the template file... 
 
@@ -32,11 +185,125 @@ function editorTemplateFile()
   return content
 end
 
--- Cache a copy of the template to avoid multiple read/writes.
-editor_template = editorTemplateFile()
+-- Obtain the editor template file at webr-context-interactive.html
+function interactiveTemplateFile()
+  return readTemplateFile("webr-context-interactive.html")
+end
 
+-- Obtain the output template file at webr-context-output.html
+function outputTemplateFile()
+  return readTemplateFile("webr-context-output.html")
+end
+
+-- Obtain the setup template file at webr-context-setup.html
+function setupTemplateFile()
+  return readTemplateFile("webr-context-setup.html")
+end
+
+-- Obtain the initialization template file at webr-init.html
+function initializationTemplateFile()
+  return readTemplateFile("webr-init.html")
+end
+
+-- Cache a copy of each public-facing templates to avoid multiple read/writes.
+interactive_template = interactiveTemplateFile()
+
+output_template = outputTemplateFile()
+
+setup_template = setupTemplateFile()
 ----
 
+-- Define a function that escape control sequence
+function escapeControlSequences(str)
+  -- Perform a global replacement on the control sequence character
+  return str:gsub("[\\%c]", function(c)
+    if c == "\\" then
+      -- Escape backslash
+      return "\\\\"
+    end
+  end)
+end
+
+-- Check if version is latest
+function isLatestVersion(str)
+  return str == "latest"
+end
+
+
+-- Verify the string is a valid version
+function isMajorMinorPatchFormat(version)
+  -- Create a regular expression pattern that matches:
+  -- major.minor.patch
+  local pattern = "^%d+%.%d+%.%d+$"
+
+  -- If the pattern matches, then we're set!
+  return string.match(version, pattern) ~= nil
+end
+
+function checkMajorMinorPatchVersionFormat(version_string)
+  -- Verify string matches a given format
+  if not isMajorMinorPatchFormat(version_string) then
+      error("Invalid version string: " .. version_string)
+  end
+  -- Empty return to use as enforcement
+  return false
+end
+
+-- Compare versions
+function compareMajorMinorPatchVersions(v1, v2)
+
+  -- Enforce a version string
+  checkMajorMinorPatchVersionFormat(v1)
+  checkMajorMinorPatchVersionFormat(v2)
+
+  -- Extract version details
+  local v1_major, v1_minor, v1_patch = v1:match("(%d+)%.(%d+)%.(%d+)")
+  local v2_major, v2_minor, v2_patch = v2:match("(%d+)%.(%d+)%.(%d+)")
+  
+  -- Perform a comparison check on the dot releases, such that:
+  -- v1 > v2 returns 1 
+  -- v2 > v1 returns -1 
+  -- v1 == v2 returns 0
+  if tonumber(v1_major) > tonumber(v2_major) then
+    return 1
+  elseif tonumber(v2_major) > tonumber(v1_major) then
+    return -1
+  elseif tonumber(v1_minor) > tonumber(v2_minor) then
+    return 1
+  elseif tonumber(v2_minor) > tonumber(v1_minor) then
+    return -1
+  elseif tonumber(v1_patch) > tonumber(v2_patch) then
+    return 1
+  elseif tonumber(v2_patch) > tonumber(v1_patch) then
+    return -1
+  else
+    return 0
+  end
+end
+----
+
+function initializationWebR()
+
+  -- Setup different WebR specific initialization variables
+  local substitutions = {
+    ["SHOWSTARTUPMESSAGE"] = showStartUpMessage, -- tostring()
+    ["SHOWHEADERMESSAGE"] = showHeaderMessage,
+    ["BASEURL"] = baseUrl, 
+    ["CHANNELTYPE"] = channelType,
+    ["SERVICEWORKERURL"] = serviceWorkerUrl, 
+    ["HOMEDIR"] = homeDir,
+    ["INSTALLRPACKAGESLIST"] = installRPackagesList
+    -- ["VERSION"] = baseVersionWebR
+  }
+  
+  -- Make sure we perform a copy
+  local initializationTemplate = initializationTemplateFile()
+
+  -- Make the necessary substitutions
+  local initializedWebRConfiguration = substitute_in_file(initializationTemplate, substitutions)
+
+  return initializedWebRConfiguration
+end
 
 -- Setup WebR's pre-requisites once per document.
 function ensureWebRSetup()
@@ -48,15 +315,36 @@ function ensureWebRSetup()
   
   -- Otherwise, let's include the initialization script _once_
   hasDoneWebRSetup = true
+
+  local initializedConfigurationWebR = initializationWebR()
   
   -- Insert the web initialization
   -- https://quarto.org/docs/extensions/lua-api.html#includes
-  quarto.doc.include_file("in-header", "webr-init.html")
+  quarto.doc.include_text("in-header", initializedConfigurationWebR)
 
-  -- Copy the two web workers into the directory
-  -- https://quarto.org/docs/extensions/lua-api.html#dependencies
-  quarto.doc.add_format_resource("webr-worker.js")	
-  quarto.doc.add_format_resource("webr-serviceworker.js")	
+  -- Insert the monaco editor initialization
+  quarto.doc.include_file("before-body", "monaco-editor-init.html")
+
+  -- If the ChannelType requires service workers, register and copy them into the 
+  -- output directory.
+  if hasServiceWorkerFiles then 
+    -- Copy the two web workers into the directory
+    -- https://quarto.org/docs/extensions/lua-api.html#dependencies
+    quarto.doc.add_html_dependency({
+      name = "webr-worker",
+      version = baseVersionWebR,
+      seviceworkers = {"webr-worker.js"}, -- Kept to avoid error text.
+      serviceworkers = {"webr-worker.js"}
+    })
+
+    quarto.doc.add_html_dependency({
+      name = "webr-serviceworker",
+      version = baseVersionWebR,
+      seviceworkers = {"webr-serviceworker.js"}, -- Kept to avoid error text.
+      serviceworkers = {"webr-serviceworker.js"}
+    })
+  end
+
 end
 
 -- Define a function to replace keywords given by {{ WORD }}
@@ -70,52 +358,127 @@ function substitute_in_file(contents, substitutions)
   return contents
 end
 
+-- Extract Quarto code cell options from the block's text
+function extractCodeBlockOptions(block)
+  
+  -- Access the text aspect of the code block
+  local code = block.text
+
+  -- Define two local tables:
+  --  the block's attributes
+  --  the block's code lines
+  local newAttributes = {}
+  local newCodeLines = {}
+
+  -- Iterate over each line in the code block 
+  for line in code:gmatch("([^\r\n]*)[\r\n]?") do
+    -- Check if the line starts with "#|" and extract the key-value pairing
+    -- e.g. #| key: value goes to newAttributes[key] -> value
+    local key, value = line:match("^#|%s*(.-):%s*(.-)%s*$")
+
+    -- If a special comment is found, then add the key-value pairing to the newAttributes table
+    if key and value then
+      newAttributes[key] = value
+    else
+      -- Otherwise, it's not a special comment, keep the code line
+      table.insert(newCodeLines, line)
+    end
+  end
+
+  -- Set the new attributes for the code block
+  block.attributes = newAttributes
+
+  -- Set the codeblock text to exclude the special comments.
+  block.text = table.concat(newCodeLines, '\n')
+
+  -- Return the full block
+  return block
+end
+
+-- Replace the code cell with a webR editor
+function enableWebRCodeCell(el)
+      
+  -- Let's see what's going on here:
+  -- quarto.log.output(el)
+  
+  -- Should display the following elements:
+  -- https://pandoc.org/lua-filters.html#type-codeblock
+  
+  -- Verify the element has attributes and the document type is HTML
+  -- not sure if this will work with an epub (may need html:js)
+  if el.attr and quarto.doc.is_format("html") then
+
+    -- Check to see if any form of the {webr} tag is present 
+
+    -- Look for the original compute cell type `{webr}` 
+    -- If the compute engine is:
+    -- - jupyter: this appears as `{webr}` 
+    -- - knitr: this appears as `webr`
+    --  since the later dislikes custom engines
+    local originalEngine = el.attr.classes:includes("{webr}") or el.attr.classes:includes("webr")
+
+    -- Check for the new engine syntax that allows for the cell to be 
+    -- evaluated in VS Code or RStudio editor views, c.f.
+    -- https://github.com/quarto-dev/quarto-cli/discussions/4761#discussioncomment-5336636
+    local newEngine = el.attr.classes:includes("{webr-r}")
+    
+    if (originalEngine or newEngine) then
+      
+      -- Make sure we've initialized the code block
+      ensureWebRSetup()
+
+      -- Modify the counter variable each time this is run to create
+      -- unique code cells
+      counter = counter + 1
+
+      -- Convert webr-specific option commands into attributes
+      el = extractCodeBlockOptions(el)
+      
+      -- 7 is the default height and width for knitr. But, that doesn't translate to pixels.
+      -- So, we have 504 and 360 respectively.
+      -- Should we check the attributes for this value? Seems odd.
+      -- https://yihui.org/knitr/options/
+      local substitutions = {
+        ["WEBRCOUNTER"] = counter, 
+        ["WIDTH"] = 504,
+        ["HEIGHT"] = 360,
+        ["WEBRCODE"] = escapeControlSequences(el.text)
+      }
+      
+      -- Retrieve the newly defined attributes
+      local cell_context = el.attributes.context
+
+      -- Decide the correct template
+      -- Make sure we perform a copy of each template
+      local copied_code_template = nil
+      if is_variable_empty(cell_context) or cell_context == "interactive" then
+        copied_code_template = interactive_template
+      elseif cell_context == "setup" then
+        copied_code_template = setup_template
+      elseif cell_context == "output" then
+        copied_code_template = output_template
+      else
+        error("The `context` option must contain either: `interactive`, `setup`, or `output`. Not the value of `".. cell_context .."`")
+      end
+
+      -- Make the necessary substitutions into the template
+      local webr_enabled_code_cell = substitute_in_file(copied_code_template, substitutions)
+
+      -- Return the modified HTML template as a raw cell
+      return pandoc.RawInline('html', webr_enabled_code_cell)
+
+    end
+  end
+  -- Allow for a pass through in other languages
+  return el
+end
 
 return {
   {
-    CodeBlock = function(el)
-      
-      -- Let's see what's going on here:
-      -- quarto.log.output(el)
-      
-      -- Should display the following elements:
-      -- https://pandoc.org/lua-filters.html#type-codeblock
-      
-      -- Ensure that the {webr} tag is present and the document type is HTML
-      -- not sure if this will work with an epub (may need html:js)
-      -- Right now, we're using `{webr}` if engine is jupyter and `webr` if engine is `knitr` since the later dislikes custom engines
-      if el.attr and (el.attr.classes:includes("{webr}") or el.attr.classes:includes("webr")) and quarto.doc.is_format("html") then
-        
-        -- Make sure we've initialized the code block
-        ensureWebRSetup()
-
-        -- Modify the counter variable each time this is run to create
-        -- unique code cells
-        counter = counter + 1
-        
-        -- 7 is the default height and width for knitr.
-        -- Should we check the attributes for this value? Seems odd.
-        -- https://yihui.org/knitr/options/
-        local substitutions = {
-          ["WEBRCOUNTER"] = counter, 
-          ["WIDTH"] = 7,
-          ["HEIGHT"] = 7,
-          ["WEBRCODE"] = el.text
-        }
-        
-        -- Make sure we perform a copy
-        local copied_editor_template = editor_template
-
-        -- Make the necessary substitutions
-        local webr_enabled_code_cell = substitute_in_file(copied_editor_template, substitutions)
-
-        -- Return the modified HTML template as a raw cell
-        return pandoc.RawInline('html', webr_enabled_code_cell)
-      end
-      
-      -- Allow for a pass through in other languages
-      return el
-    end
+    Meta = setWebRInitializationOptions
+  }, 
+  {
+    CodeBlock = enableWebRCodeCell
   }
 }
 

--- a/book/_quarto.yml
+++ b/book/_quarto.yml
@@ -1,8 +1,10 @@
 project:
   type: book
   output-dir: _book
-  post-render:
-    - add-extra-files.R
+  resources:
+    - webr-serviceworker.js
+    - webr-worker.js
+    - _headers
 
 book:
   title: "Book Title"

--- a/book/add-extra-files.R
+++ b/book/add-extra-files.R
@@ -1,7 +1,0 @@
-# Copy the required webr js files into the build directory
-file.copy("_extensions/coatless/webr/webr-serviceworker.js", "_book/webr-serviceworker.js")
-file.copy("_extensions/coatless/webr/webr-worker.js", "_book/webr-worker.js")
-
-# Copy the custom headers file for netlify to improve speed and security
-# See https://docs.r-wasm.org/webr/latest/serving.html
-file.copy("_headers", "_book/_headers")

--- a/book/basicr.qmd
+++ b/book/basicr.qmd
@@ -1,8 +1,6 @@
 ---
 title: "Basic R"
-format:
-  html:
-    include-in-header: header.html
+format: html
 filters:
   - webr
 ---

--- a/book/basicr.qmd
+++ b/book/basicr.qmd
@@ -18,13 +18,13 @@ Click `Run Code` to run the following R code.
 
 Execute this simple calculation.
 
-```{webr}
+```{webr-r}
 50 * 2.2
 ```
 
 Show the first rows of a table.
 
-```{webr}
+```{webr-r}
 head(mtcars)
 ```
 
@@ -33,7 +33,7 @@ head(mtcars)
 
 Show the last rows of the `mtcars` table.
 
-```{webr}
+```{webr-r}
 # Add you code here
 ```
 

--- a/book/ggplot.qmd
+++ b/book/ggplot.qmd
@@ -2,21 +2,11 @@
 title: "ggplot demo"
 editor: visual
 engine: knitr
+webr:
+  - packages: ['ggplot2']
 filters:
   - webr
 ---
-
-<html>
-<script type="module">
-
-import { WebR } from 'https://webr.r-wasm.org/latest/webr.mjs'; 
-globalThis.webR = new WebR({SW_URL: "https://bluegreen-labs.github.io/R_book_template/"}); 
-await globalThis.webR.init(); 
-globalThis.webRCodeShelter = await new globalThis.webR.Shelter();
-await globalThis.webR.installPackages(['ggplot2'])
-
-</script>
-</html>
 
 ::: {.callout-warning}
 Installing and loading ggplot2 on webR takes a little while.
@@ -26,13 +16,13 @@ Installing and loading ggplot2 on webR takes a little while.
 
 * Load the package and some data
 
-```{webr}
+```{webr-r}
 library(ggplot2)
 ```
 
 * create a plot 
 
-```{webr}
+```{webr-r}
 ggplot(data = mtcars, mapping = aes(x = mpg, y = hp)) +
   geom_point()
 ```
@@ -44,7 +34,7 @@ ggplot(data = mtcars, mapping = aes(x = mpg, y = hp)) +
 Make a scatter plot with `hp` on the x axis and `wt` on the y axis. Label the x axis "Horse Power" and the y axis “Weight”.
 Make one subplot for each value in `gear`.
 
-```{webr}
+```{webr-r}
 # Add you code here
 ```
 


### PR DESCRIPTION
@khufkens this PR updates the `quarto-webr` extension version used in the book from 0.0.1 to 0.3.6. 

We've modified the configuration to use the `resources` key to avoid needing to run a script after render to move files. We also changed the code cell from `{webr}` to `{webr-r}`. Lastly, we removed the hidden package installation code in favor of the `packages` key.

Close #1 